### PR TITLE
Export fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 dist-newstyle
 dist
-
+testing

--- a/src/System/Linux/IO/URing.hsc
+++ b/src/System/Linux/IO/URing.hsc
@@ -5,6 +5,7 @@ module System.Linux.IO.URing
   ( newURing
   , postSqe
   , submit
+  , submitAndWait
   , popCq
   , freeSqe
     -- * Requests

--- a/src/System/Linux/IO/URing.hsc
+++ b/src/System/Linux/IO/URing.hsc
@@ -2,7 +2,8 @@
 {-# LANGUAGE DataKinds #-}
 
 module System.Linux.IO.URing
-  ( newURing
+  ( URing
+  , newURing
   , postSqe
   , submit
   , submitAndWait

--- a/src/System/Linux/IO/URing/Ring.hsc
+++ b/src/System/Linux/IO/URing/Ring.hsc
@@ -7,6 +7,7 @@ module System.Linux.IO.URing.Ring
   ( URing
   , newURing
   , submit
+  , submitAndWait
   , getSqe
   , freeSqe
   , pushSqe

--- a/src/System/Linux/IO/URing/Ring.hsc
+++ b/src/System/Linux/IO/URing/Ring.hsc
@@ -284,7 +284,7 @@ data HsURing
     = HsURing { sqeAperture :: !(Ptr Sqe)
               , sqAperture  :: !(Ptr ())
               , cqAperture  :: !(Ptr ())
-              , hsURingFd     :: !CInt
+              , hsURingFd   :: !CInt
               , params      :: !IOURingParams
               }
 


### PR DESCRIPTION
Really minor stuff. Exporting `URing` from the main module makes sense to me because then you can write type signatures for other functions also exported from `System.Linux.IO.URing` like `popCQE`. The `submitAndWait` function was not exported at all, not even from `System.Linux.IO.URing.Ring` and I needed it for my event manager prototype.

Adding the `testing` file to gitignore is just quality of life stuff; ideally we'd already remove during some test suite but one thing at a time. 